### PR TITLE
Movie service layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <properties>
         <java.version>17</java.version>
         <aws.sdk.version>2.25.0</aws.sdk.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
     </properties>
 
     <dependencyManagement>
@@ -114,6 +115,21 @@
             <artifactId>auth</artifactId>
         </dependency>
 
+        <!-- MapStruct API -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+
+        <!-- MapStruct annotation processor -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- JSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -205,6 +221,11 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/main/java/com/lumen/awsspringbootservice/dto/movie/MovieDto.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/movie/MovieDto.java
@@ -1,0 +1,56 @@
+package com.lumen.awsspringbootservice.dto.movie;
+
+import com.lumen.awsspringbootservice.enums.Genre;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MovieDto {
+
+    private String id;
+
+    @NotBlank(message = "Author must not be blank")
+    @Size(max = 100, message = "Author name must be at most 100 characters")
+    private String author;
+
+    @NotBlank(message = "Title must not be blank")
+    @Size(min = 2, max = 150, message = "Title must be between 2 and 150 characters")
+    private String title;
+
+    @NotBlank(message = "Description must not be blank")
+    @Size(min = 10, max = 1000, message = "Description must be between 10 and 1000 characters")
+    private String description;
+
+    @NotEmpty(message = "Movie must have at least one genre")
+    private Set<Genre> genres = new HashSet<>();
+
+    @NotEmpty(message = "Movie must have at least one plan")
+    private List<@Valid MoviePlanShortDto> moviePlanShortDtoList = new ArrayList<>();
+
+    @NotNull(message = "Premiere date is required")
+    @FutureOrPresent(message = "Premiere date cannot be in the past")
+    private LocalDateTime premiereDate;
+
+    @NotBlank(message = "S3 key must not be blank")
+    private String s3Key;
+
+    @NotBlank(message = "Photo URL must not be blank")
+    @Pattern(
+            regexp = "^(https?|ftp)://.*$",
+            message = "Photo URL must be a valid URL"
+    )
+    private String photoUrl;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/movie/MoviePlanShortDto.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/movie/MoviePlanShortDto.java
@@ -1,0 +1,30 @@
+package com.lumen.awsspringbootservice.dto.movie;
+
+import com.lumen.awsspringbootservice.enums.PlanType;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MoviePlanShortDto {
+
+    private String id;
+
+    @NotNull(message = "Plan type is required")
+    private PlanType type;
+
+    @NotNull(message = "Price is required")
+    @DecimalMin(value = "0.0", inclusive = false, message = "Price must be greater than 0")
+    @Digits(integer = 10, fraction = 2, message = "Price must be a valid monetary amount")
+    private BigDecimal price;
+}
+

--- a/src/main/java/com/lumen/awsspringbootservice/entity/Movie.java
+++ b/src/main/java/com/lumen/awsspringbootservice/entity/Movie.java
@@ -39,7 +39,7 @@ public class Movie {
     @OneToMany(mappedBy = "movie", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Review> reviews = new ArrayList<>();
 
-    @OneToMany(mappedBy = "movie", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "movie", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MoviePlan> moviePlans = new ArrayList<>();
 
     @Column(name = "premiere_date")

--- a/src/main/java/com/lumen/awsspringbootservice/enums/Genre.java
+++ b/src/main/java/com/lumen/awsspringbootservice/enums/Genre.java
@@ -1,8 +1,24 @@
 package com.lumen.awsspringbootservice.enums;
 
 public enum Genre {
+    ACTION,
+    ADVENTURE,
+    ANIMATION,
+    COMEDY,
+    CRIME,
+    DOCUMENTARY,
+    DRAMA,
+    FAMILY,
     FANTASY,
+    HISTORY,
+    HORROR,
+    MUSIC,
+    MYSTERY,
+    ROMANCE,
     SCIENCE_FICTION,
-    DRAMA
+    TV_MOVIE,
+    THRILLER,
+    WAR,
+    WESTERN
 }
 

--- a/src/main/java/com/lumen/awsspringbootservice/exception/NotFoundException.java
+++ b/src/main/java/com/lumen/awsspringbootservice/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.lumen.awsspringbootservice.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    public NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/mapper/IdMapper.java
+++ b/src/main/java/com/lumen/awsspringbootservice/mapper/IdMapper.java
@@ -1,0 +1,19 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+import java.util.UUID;
+
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface IdMapper {
+    default UUID map(String id) {
+        return id != null ? UUID.fromString(id) : null;
+    }
+
+    default String map(UUID id) {
+        return id != null ? id.toString() : null;
+    }
+}
+

--- a/src/main/java/com/lumen/awsspringbootservice/mapper/MovieMapper.java
+++ b/src/main/java/com/lumen/awsspringbootservice/mapper/MovieMapper.java
@@ -1,0 +1,29 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+import com.lumen.awsspringbootservice.entity.Movie;
+import org.mapstruct.*;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        uses = {MoviePlanMapper.class, IdMapper.class})
+public interface MovieMapper {
+
+    @Mapping(target = "moviePlans", source = "moviePlanShortDtoList")
+    Movie toEntity(MovieDto dto);
+
+    @Mapping(target = "moviePlanShortDtoList", source = "moviePlans")
+    MovieDto toDto(Movie entity);
+
+    List<Movie> toEntityList(List<MovieDto> dtoList);
+
+    List<MovieDto> toDtoList(List<Movie> entityList);
+
+    @AfterMapping
+    default void linkMoviePlans(@MappingTarget Movie movie) {
+        if (movie.getMoviePlans() != null) {
+            movie.getMoviePlans().forEach(plan -> plan.setMovie(movie));
+        }
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/mapper/MoviePlanMapper.java
+++ b/src/main/java/com/lumen/awsspringbootservice/mapper/MoviePlanMapper.java
@@ -1,0 +1,16 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import com.lumen.awsspringbootservice.dto.movie.MoviePlanShortDto;
+import com.lumen.awsspringbootservice.entity.MoviePlan;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        uses = {IdMapper.class})
+public interface MoviePlanMapper {
+
+    MoviePlan toEntity(MoviePlanShortDto dto);
+
+    MoviePlanShortDto toDto(MoviePlan entity);
+}

--- a/src/main/java/com/lumen/awsspringbootservice/repository/MovieRepository.java
+++ b/src/main/java/com/lumen/awsspringbootservice/repository/MovieRepository.java
@@ -2,9 +2,10 @@ package com.lumen.awsspringbootservice.repository;
 
 import com.lumen.awsspringbootservice.entity.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.UUID;
 
-public interface MovieRepository extends JpaRepository<Movie, UUID> {
+public interface MovieRepository extends JpaRepository<Movie, UUID>, JpaSpecificationExecutor<Movie> {
 
 }

--- a/src/main/java/com/lumen/awsspringbootservice/repository/MovieRepository.java
+++ b/src/main/java/com/lumen/awsspringbootservice/repository/MovieRepository.java
@@ -2,7 +2,6 @@ package com.lumen.awsspringbootservice.repository;
 
 import com.lumen.awsspringbootservice.entity.Movie;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 

--- a/src/main/java/com/lumen/awsspringbootservice/request/MovieFilterRequest.java
+++ b/src/main/java/com/lumen/awsspringbootservice/request/MovieFilterRequest.java
@@ -1,0 +1,25 @@
+package com.lumen.awsspringbootservice.request;
+
+import com.lumen.awsspringbootservice.enums.Genre;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MovieFilterRequest {
+    private String title;
+    private Genre genre;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate premiereDateFrom;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate premiereDateTo;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/MovieService.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/MovieService.java
@@ -1,0 +1,33 @@
+package com.lumen.awsspringbootservice.service;
+
+import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+
+
+public interface MovieService {
+    /**
+     * Retrieves a movie by its identifier.
+     *
+     * @param movieId the ID of the movie as a String (UUID format).
+     * @return a {@link MovieDto} representing the movie.
+     * @throws com.lumen.awsspringbootservice.exception.NotFoundException if no movie with the given ID exists.
+     */
+    MovieDto getMovieById(String movieId);
+
+    /**
+     * Creates a new movie along with its plans.
+     *
+     * @param dto the {@link MovieDto} containing movie details and plans.
+     * @return the created {@link MovieDto} with generated identifier.
+     */
+    MovieDto createMovie(MovieDto dto);
+
+    /**
+     * Updates an existing movie and its related entities.
+     *
+     * @param dto the {@link MovieDto} containing updated movie details and plans.
+     *            Must include a valid identifier of an existing movie.
+     * @return the updated {@link MovieDto}.
+     * @throws com.lumen.awsspringbootservice.exception.NotFoundException if no movie with the given ID exists.
+     */
+    MovieDto updateMovie(MovieDto dto);
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/MovieService.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/MovieService.java
@@ -1,6 +1,9 @@
 package com.lumen.awsspringbootservice.service;
 
 import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+import com.lumen.awsspringbootservice.request.MovieFilterRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 
 public interface MovieService {
@@ -30,4 +33,22 @@ public interface MovieService {
      * @throws com.lumen.awsspringbootservice.exception.NotFoundException if no movie with the given ID exists.
      */
     MovieDto updateMovie(MovieDto dto);
+
+    /**
+     * Retrieves a paginated list of movies based on the provided filter criteria.
+     * Supported filters include title, genre, and premiere date ranges.
+     *
+     * @param filter   the {@link MovieFilterRequest} containing filtering options.
+     * @param pageable the {@link Pageable} object specifying pagination and sorting parameters.
+     * @return a {@link Page} of {@link MovieDto} matching the filter criteria.
+     */
+    Page<MovieDto> getMovies(MovieFilterRequest filter, Pageable pageable);
+
+    /**
+     * Retrieves a paginated list of all movies without applying any filters.
+     *
+     * @param pageable the {@link Pageable} object specifying pagination and sorting parameters.
+     * @return a {@link Page} of all available {@link MovieDto}.
+     */
+    Page<MovieDto> getMovies(Pageable pageable);
 }

--- a/src/main/java/com/lumen/awsspringbootservice/service/impl/MovieServiceImpl.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/impl/MovieServiceImpl.java
@@ -1,0 +1,57 @@
+package com.lumen.awsspringbootservice.service.impl;
+
+import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.exception.NotFoundException;
+import com.lumen.awsspringbootservice.mapper.MovieMapper;
+import com.lumen.awsspringbootservice.repository.MovieRepository;
+import com.lumen.awsspringbootservice.service.MovieService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MovieServiceImpl implements MovieService {
+
+    private final MovieRepository movieRepository;
+
+    private final MovieMapper movieMapper;
+
+    public MovieDto getMovieById(String movieId) {
+        log.info("Fetching movie by id: {}", movieId);
+        MovieDto dto = movieMapper.toDto(movieRepository
+                .findById(UUID.fromString(movieId))
+                .orElseThrow(() -> new NotFoundException("Movie with id " + movieId + " not found")));
+
+        log.info("Movie successfully found: {}", dto);
+        return dto;
+    }
+
+    public MovieDto createMovie(MovieDto dto) {
+        log.info("Creating new movie: {}", dto);
+        Movie entity = movieMapper.toEntity(dto);
+
+        MovieDto response = movieMapper.toDto(movieRepository.save(entity));
+
+        log.info("Movie successfully created with id: {}", response.getId());
+        return response;
+    }
+
+    public MovieDto updateMovie(MovieDto dto) {
+        log.info("Updating movie: {}", dto);
+        Movie existingEntity = movieRepository.findById(UUID.fromString(dto.getId()))
+                .orElseThrow(() -> new NotFoundException("Movie with id " + dto.getId() + " not found"));
+
+        Movie entity = movieMapper.toEntity(dto);
+
+        MovieDto response = movieMapper.toDto(movieRepository.save(entity));
+
+        log.info("Movie successfully updated");
+        return response;
+    }
+
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/impl/MovieServiceImpl.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/impl/MovieServiceImpl.java
@@ -5,9 +5,14 @@ import com.lumen.awsspringbootservice.entity.Movie;
 import com.lumen.awsspringbootservice.exception.NotFoundException;
 import com.lumen.awsspringbootservice.mapper.MovieMapper;
 import com.lumen.awsspringbootservice.repository.MovieRepository;
+import com.lumen.awsspringbootservice.request.MovieFilterRequest;
 import com.lumen.awsspringbootservice.service.MovieService;
+import com.lumen.awsspringbootservice.util.MovieSpecifications;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -52,6 +57,32 @@ public class MovieServiceImpl implements MovieService {
 
         log.info("Movie successfully updated");
         return response;
+    }
+
+    public Page<MovieDto> getMovies(MovieFilterRequest filter, Pageable pageable) {
+        log.info("Fetching movies with filters: {}, page {}, size {}", filter, pageable.getPageNumber(), pageable.getPageSize());
+
+        Specification<Movie> spec = Specification.
+                allOf(MovieSpecifications.title(filter.getTitle()))
+                .and(MovieSpecifications.genre(filter.getGenre()))
+                .and(MovieSpecifications.premiereDateAfter(filter.getPremiereDateFrom()))
+                .and(MovieSpecifications.premiereDateBefore(filter.getPremiereDateTo()));
+
+        Page<MovieDto> result = movieRepository.findAll(spec, pageable)
+                .map(movieMapper::toDto);
+
+        log.info("Found {} movies", result.getTotalElements());
+        return result;
+    }
+
+    public Page<MovieDto> getMovies(Pageable pageable) {
+        log.info("Fetching movies, page {}, size {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<MovieDto> result = movieRepository.findAll(pageable)
+                .map(movieMapper::toDto);
+
+        log.info("Found {} movies", result.getTotalElements());
+        return result;
     }
 
 }

--- a/src/main/java/com/lumen/awsspringbootservice/util/MovieSpecifications.java
+++ b/src/main/java/com/lumen/awsspringbootservice/util/MovieSpecifications.java
@@ -1,0 +1,30 @@
+package com.lumen.awsspringbootservice.util;
+
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.enums.Genre;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+
+public class MovieSpecifications {
+
+    public static Specification<Movie> title(String title) {
+        return (root, query, criteriaBuilder) ->
+                title == null ? null : criteriaBuilder.like(criteriaBuilder.lower(root.get("title")), "%" + title.toLowerCase() + "%");
+    }
+
+    public static Specification<Movie> genre(Genre genre) {
+        return (root, query, criteriaBuilder) ->
+                genre == null ? null : criteriaBuilder.isMember(genre, root.get("genres"));
+    }
+
+    public static Specification<Movie> premiereDateAfter(LocalDate from) {
+        return (root, query, cb) ->
+                from == null ? null : cb.greaterThanOrEqualTo(root.get("premiereDate"), from.atStartOfDay());
+    }
+
+    public static Specification<Movie> premiereDateBefore(LocalDate to) {
+        return (root, query, cb) ->
+                to == null ? null : cb.lessThanOrEqualTo(root.get("premiereDate"), to.atTime(23, 59, 59));
+    }
+}

--- a/src/test/java/com/lumen/awsspringbootservice/mapper/BaseMapperTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/mapper/BaseMapperTest.java
@@ -1,0 +1,63 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+import com.lumen.awsspringbootservice.dto.movie.MoviePlanShortDto;
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.entity.MoviePlan;
+import com.lumen.awsspringbootservice.enums.Genre;
+import com.lumen.awsspringbootservice.enums.PlanType;
+import org.junit.jupiter.api.DisplayName;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@DisplayName("Base Mapper Test")
+public abstract class BaseMapperTest {
+    protected Movie buildMovieEntity() {
+        return Movie.builder()
+                .id(UUID.randomUUID())
+                .author("author_" + UUID.randomUUID())
+                .title("Movie " + UUID.randomUUID())
+                .description("Some test description")
+                .premiereDate(LocalDateTime.now().minusDays(10))
+                .genres(Set.of(Genre.DRAMA, Genre.FANTASY))
+                .s3Key("test-s3-key")
+                .photoUrl("https://photo.example.com/movie.jpg")
+                .moviePlans(List.of(buildMoviePlanEntity(null, PlanType.WEEK)))
+                .build();
+    }
+
+    protected MoviePlan buildMoviePlanEntity(Movie movie, PlanType type) {
+        return MoviePlan.builder()
+                .id(UUID.randomUUID())
+                .movie(movie)
+                .type(type)
+                .price(new BigDecimal("9.99"))
+                .build();
+    }
+
+    protected MovieDto buildMovieDto() {
+        return MovieDto.builder()
+                .id(UUID.randomUUID().toString())
+                .author("author_" + UUID.randomUUID())
+                .title("Movie DTO " + UUID.randomUUID())
+                .description("DTO test description")
+                .premiereDate(LocalDateTime.now().minusDays(5))
+                .genres(Set.of(Genre.FANTASY))
+                .s3Key("dto-s3-key")
+                .photoUrl("https://photo.example.com/dto.jpg")
+                .moviePlanShortDtoList(List.of(buildMoviePlanShortDto(PlanType.MONTH)))
+                .build();
+    }
+
+    protected MoviePlanShortDto buildMoviePlanShortDto(PlanType type) {
+        return MoviePlanShortDto.builder()
+                .id(UUID.randomUUID().toString())
+                .type(type)
+                .price(new BigDecimal("19.99"))
+                .build();
+    }
+}

--- a/src/test/java/com/lumen/awsspringbootservice/mapper/IdMapperTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/mapper/IdMapperTest.java
@@ -1,0 +1,83 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(
+        classes = {
+                IdMapperImpl.class
+        },
+        properties = {"spring.profiles.active=test"}
+)
+@DisplayName("IdMapper Unit Tests")
+class IdMapperTest {
+
+    @Autowired
+    private IdMapper idMapper;
+
+    @Nested
+    @DisplayName("String to UUID Mapping")
+    class StringToUuidMapping {
+
+        @Test
+        @DisplayName("Should map valid String to UUID")
+        void shouldMapStringToUuid() {
+            // given
+            UUID expected = UUID.randomUUID();
+            String uuidStr = expected.toString();
+
+            // when
+            UUID result = idMapper.map(uuidStr);
+
+            // then
+            assertNotNull(result);
+            assertEquals(expected, result);
+        }
+
+        @Test
+        @DisplayName("Should return null when input String is null")
+        void shouldReturnNullWhenStringIsNull() {
+            // when
+            UUID result = idMapper.map((String) null);
+
+            // then
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("UUID to String Mapping")
+    class UuidToStringMapping {
+
+        @Test
+        @DisplayName("Should map valid UUID to String")
+        void shouldMapUuidToString() {
+            // given
+            UUID uuid = UUID.randomUUID();
+
+            // when
+            String result = idMapper.map(uuid);
+
+            // then
+            assertNotNull(result);
+            assertEquals(uuid.toString(), result);
+        }
+
+        @Test
+        @DisplayName("Should return null when input UUID is null")
+        void shouldReturnNullWhenUuidIsNull() {
+            // when
+            String result = idMapper.map((UUID) null);
+
+            // then
+            assertNull(result);
+        }
+    }
+}

--- a/src/test/java/com/lumen/awsspringbootservice/mapper/MovieMapperTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/mapper/MovieMapperTest.java
@@ -1,0 +1,106 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+import com.lumen.awsspringbootservice.dto.movie.MoviePlanShortDto;
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.entity.MoviePlan;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(
+        classes = {
+                IdMapperImpl.class,
+                MoviePlanMapperImpl.class,
+                MovieMapperImpl.class
+        },
+        properties = {"spring.profiles.active=test"}
+)
+@DisplayName("MovieMapper Unit Tests")
+class MovieMapperTest extends BaseMapperTest {
+
+    @Autowired
+    private MovieMapper movieMapper;
+
+    @Nested
+    @DisplayName("DTO to Entity Mapping")
+    class DtoToEntityMapping {
+
+        @Test
+        @DisplayName("Should map MovieDto to Movie entity including MoviePlans")
+        void shouldMapDtoToEntity() {
+            // given
+            MovieDto dto = buildMovieDto();
+
+            // when
+            Movie entity = movieMapper.toEntity(dto);
+
+            // then
+            assertNotNull(entity);
+            assertEquals(dto.getTitle(), entity.getTitle());
+            assertEquals(dto.getDescription(), entity.getDescription());
+            assertEquals(dto.getGenres(), entity.getGenres());
+            assertNotNull(entity.getMoviePlans());
+            assertEquals(dto.getMoviePlanShortDtoList().size(), entity.getMoviePlans().size());
+
+            // check linkMoviePlans worked
+            for (MoviePlan plan : entity.getMoviePlans()) {
+                assertNotNull(plan.getMovie());
+                assertEquals(entity, plan.getMovie());
+            }
+        }
+
+        @Test
+        @DisplayName("Should return null when mapping null dto")
+        void shouldReturnNullWhenDtoIsNull() {
+            // when
+            Movie entity = movieMapper.toEntity(null);
+
+            // then
+            assertNull(entity);
+        }
+    }
+
+    @Nested
+    @DisplayName("Entity to DTO Mapping")
+    class EntityToDtoMapping {
+
+        @Test
+        @DisplayName("Should map Movie entity to MovieDto including MoviePlans")
+        void shouldMapEntityToDto() {
+            // given
+            Movie entity = buildMovieEntity();
+
+            // when
+            MovieDto dto = movieMapper.toDto(entity);
+
+            // then
+            assertNotNull(dto);
+            assertEquals(entity.getTitle(), dto.getTitle());
+            assertEquals(entity.getDescription(), dto.getDescription());
+            assertEquals(entity.getGenres(), dto.getGenres());
+            assertNotNull(dto.getMoviePlanShortDtoList());
+            assertEquals(entity.getMoviePlans().size(), dto.getMoviePlanShortDtoList().size());
+
+            MoviePlanShortDto planDto = dto.getMoviePlanShortDtoList().get(0);
+            MoviePlan plan = entity.getMoviePlans().get(0);
+
+            assertEquals(plan.getType(), planDto.getType());
+            assertEquals(plan.getPrice(), planDto.getPrice());
+        }
+
+        @Test
+        @DisplayName("Should return null when mapping null entity")
+        void shouldReturnNullWhenEntityIsNull() {
+            // when
+            MovieDto dto = movieMapper.toDto(null);
+
+            // then
+            assertNull(dto);
+        }
+    }
+}

--- a/src/test/java/com/lumen/awsspringbootservice/mapper/MoviePlanMapperTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/mapper/MoviePlanMapperTest.java
@@ -1,0 +1,92 @@
+package com.lumen.awsspringbootservice.mapper;
+
+import com.lumen.awsspringbootservice.dto.movie.MoviePlanShortDto;
+import com.lumen.awsspringbootservice.entity.MoviePlan;
+import com.lumen.awsspringbootservice.enums.PlanType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(
+        classes = {
+                IdMapperImpl.class,
+                MoviePlanMapperImpl.class
+        },
+        properties = {
+                "spring.profiles.active=test"
+        })
+@DisplayName("MoviePlanMapper Unit Tests")
+class MoviePlanMapperTest extends BaseMapperTest {
+
+    @Autowired
+    private MoviePlanMapper moviePlanMapper;
+
+    @Nested
+    @DisplayName("DTO to Entity Mapping")
+    class DtoToEntityMapping {
+
+        @Test
+        @DisplayName("Should map MoviePlanShortDto to MoviePlan entity")
+        void shouldMapDtoToEntity() {
+            // given
+            MoviePlanShortDto dto = buildMoviePlanShortDto(PlanType.MONTH);
+
+            // when
+            MoviePlan entity = moviePlanMapper.toEntity(dto);
+
+            // then
+            assertNotNull(entity);
+            assertEquals(dto.getId(), entity.getId().toString());
+            assertEquals(dto.getType(), entity.getType());
+            assertEquals(dto.getPrice(), entity.getPrice());
+        }
+
+        @Test
+        @DisplayName("Should return null when mapping null dto")
+        void shouldReturnNullWhenDtoIsNull() {
+            // when
+            MoviePlan entity = moviePlanMapper.toEntity(null);
+
+            // then
+            assertNull(entity);
+        }
+    }
+
+    @Nested
+    @DisplayName("Entity to DTO Mapping")
+    class EntityToDtoMapping {
+
+        @Test
+        @DisplayName("Should map MoviePlan entity to MoviePlanShortDto")
+        void shouldMapEntityToDto() {
+            // given
+            MoviePlan entity = buildMoviePlanEntity(null, PlanType.WEEK);
+            entity.setPrice(new BigDecimal("14.99"));
+
+            // when
+            MoviePlanShortDto dto = moviePlanMapper.toDto(entity);
+
+            // then
+            assertNotNull(dto);
+            assertEquals(entity.getId().toString(), dto.getId());
+            assertEquals(entity.getType(), dto.getType());
+            assertEquals(entity.getPrice(), dto.getPrice());
+        }
+
+        @Test
+        @DisplayName("Should return null when mapping null entity")
+        void shouldReturnNullWhenEntityIsNull() {
+            // when
+            MoviePlanShortDto dto = moviePlanMapper.toDto(null);
+
+            // then
+            assertNull(dto);
+        }
+    }
+}

--- a/src/test/java/com/lumen/awsspringbootservice/repository/BaseRepositoryTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/repository/BaseRepositoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -28,7 +29,7 @@ public abstract class BaseRepositoryTest {
                 .title("Movie " + UUID.randomUUID())
                 .description("Some test description")
                 .premiereDate(LocalDateTime.now().minusDays(10))
-                .genres(Set.of(Genre.DRAMA, Genre.FANTASY))
+                .genres(new HashSet<>(Set.of(Genre.DRAMA, Genre.FANTASY)))
                 .s3Key("test-s3")
                 .author("author")
                 .photoUrl("https://photo.example.com")

--- a/src/test/java/com/lumen/awsspringbootservice/repository/BaseRepositoryTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/repository/BaseRepositoryTest.java
@@ -2,11 +2,10 @@ package com.lumen.awsspringbootservice.repository;
 
 import com.lumen.awsspringbootservice.entity.*;
 import com.lumen.awsspringbootservice.entity.Record;
-import com.lumen.awsspringbootservice.entity.User;
-import com.lumen.awsspringbootservice.enums.*;
+import com.lumen.awsspringbootservice.enums.Genre;
+import com.lumen.awsspringbootservice.enums.PlanType;
+import com.lumen.awsspringbootservice.enums.Role;
 import org.junit.jupiter.api.DisplayName;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;

--- a/src/test/java/com/lumen/awsspringbootservice/repository/MoviePlanRepositoryTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/repository/MoviePlanRepositoryTest.java
@@ -1,11 +1,8 @@
 package com.lumen.awsspringbootservice.repository;
 
+import com.lumen.awsspringbootservice.entity.Movie;
 import com.lumen.awsspringbootservice.entity.MoviePlan;
 import com.lumen.awsspringbootservice.enums.PlanType;
-import org.junit.jupiter.api.DisplayName;
-import org.springframework.boot.test.context.SpringBootTest;
-
-import com.lumen.awsspringbootservice.entity.Movie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/lumen/awsspringbootservice/repository/MoviePlanRepositoryTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/repository/MoviePlanRepositoryTest.java
@@ -7,8 +7,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -16,9 +17,8 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest(properties = {
-        "spring.profiles.active=test"
-})
+@DataJpaTest
+@ActiveProfiles("test")
 @DisplayName("MovieRepository Integration Tests")
 class MoviePlanRepositoryTest extends BaseRepositoryTest {
 

--- a/src/test/java/com/lumen/awsspringbootservice/repository/MovieRepositoryTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/repository/MovieRepositoryTest.java
@@ -5,17 +5,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest(properties = {
-        "spring.profiles.active=test"
-})
+@DataJpaTest
+@ActiveProfiles("test")
 @DisplayName("MovieRepository Integration Tests")
 class MovieRepositoryTest extends BaseRepositoryTest {
 

--- a/src/test/java/com/lumen/awsspringbootservice/service/MovieServiceImplTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/service/MovieServiceImplTest.java
@@ -5,6 +5,7 @@ import com.lumen.awsspringbootservice.entity.Movie;
 import com.lumen.awsspringbootservice.exception.NotFoundException;
 import com.lumen.awsspringbootservice.mapper.MovieMapper;
 import com.lumen.awsspringbootservice.repository.MovieRepository;
+import com.lumen.awsspringbootservice.request.MovieFilterRequest;
 import com.lumen.awsspringbootservice.service.impl.MovieServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,11 +14,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -145,6 +152,76 @@ class MovieServiceImplTest {
             // then
             assertThrows(NotFoundException.class, () -> movieService.updateMovie(dto));
             verify(movieRepository).findById(movieId);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMovies with filter Tests")
+    class GetMoviesWithFilterTests {
+
+        @Test
+        @DisplayName("Should return movies page when filter applied")
+        void shouldReturnMoviesWithFilter() {
+            // given
+            MovieFilterRequest filter = new MovieFilterRequest();
+            filter.setTitle("test");
+
+            Movie entity = new Movie();
+            entity.setId(UUID.randomUUID());
+            MovieDto dto = new MovieDto();
+            dto.setId(entity.getId().toString());
+
+            PageRequest pageable = PageRequest.of(0, 5);
+            Page<Movie> entitiesPage = new PageImpl<>(List.of(entity));
+            Page<MovieDto> expectedPage = new PageImpl<>(List.of(dto));
+
+            when(movieRepository.findAll(any(Specification.class), any(PageRequest.class)))
+                    .thenReturn(entitiesPage);
+            when(movieMapper.toDto(entity)).thenReturn(dto);
+
+            // when
+            Page<MovieDto> result = movieService.getMovies(filter, pageable);
+
+            // then
+            assertNotNull(result);
+            assertEquals(expectedPage.getContent().size(), result.getContent().size());
+            assertEquals(dto.getId(), result.getContent().get(0).getId());
+
+            verify(movieRepository).findAll(any(Specification.class), any(PageRequest.class));
+            verify(movieMapper).toDto(entity);
+        }
+    }
+
+    @Nested
+    @DisplayName("getMovies without filter Tests")
+    class GetMoviesWithoutFilterTests {
+
+        @Test
+        @DisplayName("Should return movies page without filter")
+        void shouldReturnMoviesWithoutFilter() {
+            // given
+            Movie entity = new Movie();
+            entity.setId(UUID.randomUUID());
+            MovieDto dto = new MovieDto();
+            dto.setId(entity.getId().toString());
+
+            PageRequest pageable = PageRequest.of(0, 5);
+            Page<Movie> entitiesPage = new PageImpl<>(List.of(entity));
+            Page<MovieDto> expectedPage = new PageImpl<>(List.of(dto));
+
+            when(movieRepository.findAll(pageable)).thenReturn(entitiesPage);
+            when(movieMapper.toDto(entity)).thenReturn(dto);
+
+            // when
+            Page<MovieDto> result = movieService.getMovies(pageable);
+
+            // then
+            assertNotNull(result);
+            assertEquals(expectedPage.getContent().size(), result.getContent().size());
+            assertEquals(dto.getId(), result.getContent().get(0).getId());
+
+            verify(movieRepository).findAll(pageable);
+            verify(movieMapper).toDto(entity);
         }
     }
 }

--- a/src/test/java/com/lumen/awsspringbootservice/service/MovieServiceImplTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/service/MovieServiceImplTest.java
@@ -1,0 +1,150 @@
+package com.lumen.awsspringbootservice.service;
+
+import com.lumen.awsspringbootservice.dto.movie.MovieDto;
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.exception.NotFoundException;
+import com.lumen.awsspringbootservice.mapper.MovieMapper;
+import com.lumen.awsspringbootservice.repository.MovieRepository;
+import com.lumen.awsspringbootservice.service.impl.MovieServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MovieServiceImpl Unit Tests")
+class MovieServiceImplTest {
+
+    @Mock
+    private MovieRepository movieRepository;
+
+    @Mock
+    private MovieMapper movieMapper;
+
+    @InjectMocks
+    private MovieServiceImpl movieService;
+
+    @Nested
+    @DisplayName("getMovieById Tests")
+    class GetMovieByIdTests {
+
+        @Test
+        @DisplayName("Should return MovieDto when movie exists")
+        void shouldReturnMovieDtoWhenExists() {
+            // given
+            UUID movieId = UUID.randomUUID();
+            Movie movie = new Movie();
+            MovieDto dto = new MovieDto();
+            when(movieRepository.findById(movieId)).thenReturn(Optional.of(movie));
+            when(movieMapper.toDto(movie)).thenReturn(dto);
+
+            // when
+            MovieDto result = movieService.getMovieById(movieId.toString());
+
+            // then
+            assertNotNull(result);
+            verify(movieRepository).findById(movieId);
+            verify(movieMapper).toDto(movie);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when movie does not exist")
+        void shouldThrowNotFoundWhenNotExists() {
+            // given
+            UUID movieId = UUID.randomUUID();
+            when(movieRepository.findById(movieId)).thenReturn(Optional.empty());
+
+            // then
+            assertThrows(NotFoundException.class,
+                    () -> movieService.getMovieById(movieId.toString()));
+        }
+    }
+
+    @Nested
+    @DisplayName("createMovie Tests")
+    class CreateMovieTests {
+
+        @Test
+        @DisplayName("Should save and return MovieDto")
+        void shouldSaveAndReturnMovieDto() {
+            // given
+            MovieDto dto = new MovieDto();
+            Movie entity = new Movie();
+            Movie savedEntity = new Movie();
+            MovieDto savedDto = new MovieDto();
+
+            when(movieMapper.toEntity(dto)).thenReturn(entity);
+            when(movieRepository.save(entity)).thenReturn(savedEntity);
+            when(movieMapper.toDto(savedEntity)).thenReturn(savedDto);
+
+            // when
+            MovieDto result = movieService.createMovie(dto);
+
+            // then
+            assertNotNull(result);
+            assertEquals(savedDto, result);
+            verify(movieMapper).toEntity(dto);
+            verify(movieRepository).save(entity);
+            verify(movieMapper).toDto(savedEntity);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMovie Tests")
+    class UpdateMovieTests {
+
+        @Test
+        @DisplayName("Should update and return MovieDto when movie exists")
+        void shouldUpdateMovieWhenExists() {
+            // given
+            UUID movieId = UUID.randomUUID();
+            MovieDto dto = new MovieDto();
+            dto.setId(movieId.toString());
+            Movie existingEntity = new Movie();
+            Movie entity = new Movie();
+            Movie savedEntity = new Movie();
+            MovieDto savedDto = new MovieDto();
+
+            when(movieRepository.findById(movieId)).thenReturn(Optional.of(existingEntity));
+            when(movieMapper.toEntity(dto)).thenReturn(entity);
+            when(movieRepository.save(entity)).thenReturn(savedEntity);
+            when(movieMapper.toDto(savedEntity)).thenReturn(savedDto);
+
+            // when
+            MovieDto result = movieService.updateMovie(dto);
+
+            // then
+            assertNotNull(result);
+            assertEquals(savedDto, result);
+            verify(movieRepository).findById(movieId);
+            verify(movieMapper).toEntity(dto);
+            verify(movieRepository).save(entity);
+            verify(movieMapper).toDto(savedEntity);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when movie does not exist")
+        void shouldThrowNotFoundWhenUpdatingNonexistentMovie() {
+            // given
+            UUID movieId = UUID.randomUUID();
+            MovieDto dto = new MovieDto();
+            dto.setId(movieId.toString());
+
+            when(movieRepository.findById(movieId)).thenReturn(Optional.empty());
+
+            // then
+            assertThrows(NotFoundException.class, () -> movieService.updateMovie(dto));
+            verify(movieRepository).findById(movieId);
+        }
+    }
+}

--- a/src/test/java/com/lumen/awsspringbootservice/util/MovieSpecificationsTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/util/MovieSpecificationsTest.java
@@ -1,0 +1,173 @@
+package com.lumen.awsspringbootservice.util;
+
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.enums.Genre;
+import com.lumen.awsspringbootservice.repository.BaseRepositoryTest;
+import com.lumen.awsspringbootservice.repository.MovieRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("MovieSpecifications Integration Tests")
+class MovieSpecificationsTest extends BaseRepositoryTest {
+
+    @Autowired
+    private MovieRepository movieRepository;
+
+    @Nested
+    @DisplayName("Title Specification")
+    class TitleSpecification {
+
+        @Test
+        @DisplayName("Should find movie by title containing substring")
+        void shouldFindByTitle() {
+            // given
+            Movie movie = buildMovie();
+            movie.setTitle("The Lord of the Rings");
+            movieRepository.save(movie);
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.title("rings"))
+            );
+
+            // then
+            assertEquals(1, result.size());
+            assertTrue(result.get(0).getTitle().contains("Rings"));
+        }
+
+        @Test
+        @DisplayName("Should return all movies when title is null")
+        void shouldReturnAllWhenTitleNull() {
+            // given
+            movieRepository.save(buildMovie());
+            movieRepository.save(buildMovie());
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.title(null))
+            );
+
+            // then
+            assertEquals(2, result.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Genre Specification")
+    class GenreSpecification {
+
+        @Test
+        @DisplayName("Should find movie by genre")
+        void shouldFindByGenre() {
+            // given
+            Movie movie = buildMovie();
+            movie.setGenres(new HashSet<>(Set.of(Genre.DRAMA, Genre.FANTASY)));
+            movieRepository.save(movie);
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.genre(Genre.DRAMA))
+            );
+
+            // then
+            assertEquals(1, result.size());
+            assertTrue(result.get(0).getGenres().contains(Genre.DRAMA));
+        }
+
+        @Test
+        @DisplayName("Should return all movies when genre is null")
+        void shouldReturnAllWhenGenreNull() {
+            // given
+            movieRepository.save(buildMovie());
+            movieRepository.save(buildMovie());
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.genre(null))
+            );
+
+            // then
+            assertEquals(2, result.size());
+        }
+    }
+
+    @Nested
+    @DisplayName("Premiere Date Specification")
+    class PremiereDateSpecification {
+
+        @Test
+        @DisplayName("Should find movies after given date")
+        void shouldFindAfterDate() {
+            // given
+            Movie oldMovie = buildMovie();
+            oldMovie.setPremiereDate(LocalDate.of(2000, 1, 1).atStartOfDay());
+            movieRepository.save(oldMovie);
+
+            Movie newMovie = buildMovie();
+            newMovie.setPremiereDate(LocalDate.of(2023, 1, 1).atStartOfDay());
+            movieRepository.save(newMovie);
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.premiereDateAfter(LocalDate.of(2022, 1, 1)))
+            );
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals(newMovie.getId(), result.get(0).getId());
+        }
+
+        @Test
+        @DisplayName("Should find movies before given date")
+        void shouldFindBeforeDate() {
+            // given
+            Movie oldMovie = buildMovie();
+            oldMovie.setPremiereDate(LocalDate.of(2000, 1, 1).atStartOfDay());
+            movieRepository.save(oldMovie);
+
+            Movie newMovie = buildMovie();
+            newMovie.setPremiereDate(LocalDate.of(2023, 1, 1).atStartOfDay());
+            movieRepository.save(newMovie);
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.premiereDateBefore(LocalDate.of(2010, 1, 1)))
+            );
+
+            // then
+            assertEquals(1, result.size());
+            assertEquals(oldMovie.getId(), result.get(0).getId());
+        }
+
+        @Test
+        @DisplayName("Should return all movies when date filter is null")
+        void shouldReturnAllWhenDateIsNull() {
+            // given
+            movieRepository.save(buildMovie());
+            movieRepository.save(buildMovie());
+
+            // when
+            List<Movie> result = movieRepository.findAll(
+                    Specification.allOf(MovieSpecifications.premiereDateBefore(null))
+            );
+
+            // then
+            assertEquals(2, result.size());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Introduced a complete service layer for the `Movie` domain, including DTOs, mappers, specifications, and utilities.  
All necessary unit and integration tests were implemented.

### Service Layer
- Implemented `MovieService` and `MovieServiceImpl` with CRUD operations.  
- Added support for pagination and filtering via JPA specifications.

### Mappers & DTOs
- Created `MovieDto` and `MoviePlanShortDto` for data transfer.  
- Implemented `MovieMapper`, `MoviePlanMapper`, and `IdMapper` using MapStruct.

### Utilities
- Added `MovieSpecifications` to handle dynamic filtering (title, genre, premiere date).  
- Introduced base test utilities for building entities and DTOs.

### Tests
- Covered service, mappers, and specifications with dedicated unit and integration tests.  
- Ensured isolated database state for reliable execution.

### Test Coverage:
<img width="845" height="187" alt="image" src="https://github.com/user-attachments/assets/0e0c056a-a98c-446e-9054-46dcd0d61726" />

### Build and Tests:
<img width="755" height="162" alt="image" src="https://github.com/user-attachments/assets/e163f3d0-ced0-42b8-bcaa-c21de4227d6a" />
<img width="642" height="176" alt="image" src="https://github.com/user-attachments/assets/513abd7d-e9b7-4dbb-8284-efed72a326ad" />
