### PR TITLE
Movie purchase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <groupId>org.springframework.amqp</groupId>
             <artifactId>spring-rabbit-stream</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
 
         <!-- PostgreSQL -->
         <dependency>

--- a/src/main/java/com/lumen/awsspringbootservice/controller/impl/MockPaymentController.java
+++ b/src/main/java/com/lumen/awsspringbootservice/controller/impl/MockPaymentController.java
@@ -1,0 +1,73 @@
+package com.lumen.awsspringbootservice.controller.impl;
+
+import com.lumen.awsspringbootservice.dto.request.purchase.CreatePaymentSessionRequest;
+import com.lumen.awsspringbootservice.dto.response.purchase.CreatePaymentSessionResponse;
+import com.lumen.awsspringbootservice.service.MockPaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/v1/mock/payments")
+@RequiredArgsConstructor
+public class MockPaymentController {
+
+    private final MockPaymentService mockPaymentService;
+
+    @Value("${server.host:localhost}")
+    private String serverHost;
+
+    @Value("${server.port:8080}")
+    private String serverPort;
+
+
+    @PostMapping("/create-session")
+    public ResponseEntity<CreatePaymentSessionResponse> createSession(@RequestBody CreatePaymentSessionRequest request) {
+
+        String sessionId = mockPaymentService.createPaymentSession(request);
+        String paymentUrl = "http://" + serverHost + ":" + serverPort + "/api/v1/mock/payments/checkout?sessionId=" + sessionId;
+        return ResponseEntity.ok(new CreatePaymentSessionResponse(paymentUrl));
+    }
+
+    @GetMapping(value = "/checkout", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> checkout(@RequestParam String sessionId) {
+        mockPaymentService.getPaymentSessionById(sessionId);
+        String html = """
+                <html>
+                  <body style="font-family: sans-serif; text-align:center;">
+                    <h2>Mock Payment Gateway</h2>
+                    <p>Session: %s</p>
+                    <a href="http://localhost:8080/api/v1/mock/payments/confirm?sessionId=%s">✅ Confirm Payment</a><br><br>
+                    <a href="http://localhost:8080/api/v1/mock/payments/cancel?sessionId=%s">❌ Cancel Payment</a>
+                  </body>
+                </html>
+                """.formatted(sessionId, sessionId, sessionId);
+        return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(html);
+    }
+
+    @PostMapping(value = "/confirm", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> confirm(@RequestParam String sessionId) {
+        mockPaymentService.approvePaymentSession(sessionId);
+
+        return ResponseEntity.ok("""
+                    <html><body style="text-align:center;">
+                    <h3>✅ Payment successful!</h3>
+                    <p>You can close this window now.</p>
+                    </body></html>
+                """);
+    }
+
+    @PostMapping(value = "/cancel", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> cancel(@RequestParam String sessionId) {
+        mockPaymentService.cancelPaymentSession(sessionId);
+
+        return ResponseEntity.ok("""
+                    <html><body style="text-align:center;">
+                    <h3>❌ Payment cancelled!</h3>
+                    <p>You can close this window now.</p>
+                    </body></html>
+                """);
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/controller/impl/MovieControllerImpl.java
+++ b/src/main/java/com/lumen/awsspringbootservice/controller/impl/MovieControllerImpl.java
@@ -8,8 +8,10 @@ import com.lumen.awsspringbootservice.dto.request.MovieUploadUrlsRequest;
 import com.lumen.awsspringbootservice.dto.response.MovieDetailsResponse;
 import com.lumen.awsspringbootservice.dto.response.MovieResponse;
 import com.lumen.awsspringbootservice.dto.response.MovieUploadUrlsResponse;
+import com.lumen.awsspringbootservice.dto.response.purchase.CreatePaymentSessionResponse;
 import com.lumen.awsspringbootservice.mapper.MovieMapper;
 import com.lumen.awsspringbootservice.service.MovieService;
+import com.lumen.awsspringbootservice.service.PurchaseService;
 import com.lumen.awsspringbootservice.validator.annotation.ValidImageFile;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
@@ -33,6 +35,8 @@ public class MovieControllerImpl implements MovieController {
     private final MovieService movieService;
 
     private final MovieMapper movieMapper;
+
+    private final PurchaseService purchaseService;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -96,5 +100,19 @@ public class MovieControllerImpl implements MovieController {
                 .header(HttpHeaders.CONTENT_TYPE, "application/vnd.apple.mpegurl")
                 .body(movieService.getMovieVideoUrl(id)
                 );
+    }
+
+
+    @PostMapping("/{id}/{moviePlanId}/purchase")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<CreatePaymentSessionResponse> purchaseMovie(
+            @PathVariable("id") String movieId,
+            @PathVariable("moviePlanId") String moviePlanId,
+            @RequestParam("userId") String userId
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                new CreatePaymentSessionResponse(purchaseService.
+                        createPurchaseSession(movieId, moviePlanId, userId))
+        );
     }
 }

--- a/src/main/java/com/lumen/awsspringbootservice/controller/impl/PurchaseCallbackControllerImpl.java
+++ b/src/main/java/com/lumen/awsspringbootservice/controller/impl/PurchaseCallbackControllerImpl.java
@@ -1,0 +1,32 @@
+package com.lumen.awsspringbootservice.controller.impl;
+
+import com.lumen.awsspringbootservice.dto.request.purchase.PaymentSessionResultRequest;
+import com.lumen.awsspringbootservice.dto.response.StandardMessageResponse;
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+import com.lumen.awsspringbootservice.service.PurchaseService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/lumen/purchases/callback")
+public class PurchaseCallbackControllerImpl {
+
+    private final PurchaseService purchaseService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<StandardMessageResponse> processRequest(
+            @RequestBody @Valid PaymentSessionResultRequest request
+    ) {
+        purchaseService.setPurchaseSessionResult(request.getPurchaseId(), request.getStatus());
+        if (request.getStatus().equals(PurchaseStatus.SUCCESS)) {
+            return ResponseEntity.status(HttpStatus.OK).body(StandardMessageResponse.builder().message("Purchase has been approved").build());
+        } else {
+            return ResponseEntity.status(HttpStatus.OK).body(StandardMessageResponse.builder().message("Purchase has been rejected").build());
+        }
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/purchase/PurchaseDto.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/purchase/PurchaseDto.java
@@ -1,0 +1,23 @@
+package com.lumen.awsspringbootservice.dto.purchase;
+
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.entity.User;
+import com.lumen.awsspringbootservice.enums.PlanType;
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+
+import java.time.LocalDateTime;
+
+public class PurchaseDto {
+    private String id;
+
+    private User user;
+
+    private Movie movie;
+
+    private PlanType selectedPlanType;
+
+    private LocalDateTime purchasedAt;
+    private LocalDateTime expiresAt;
+
+    private PurchaseStatus purchaseStatus;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/request/purchase/CreatePaymentSessionRequest.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/request/purchase/CreatePaymentSessionRequest.java
@@ -1,0 +1,16 @@
+package com.lumen.awsspringbootservice.dto.request.purchase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreatePaymentSessionRequest {
+    private String webhookUrl;
+    private String userId;
+    private String purchaseId;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/request/purchase/CreatePurchaseRequest.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/request/purchase/CreatePurchaseRequest.java
@@ -1,0 +1,14 @@
+package com.lumen.awsspringbootservice.dto.request.purchase;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreatePurchaseRequest {
+    private String moviePlanId;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/request/purchase/PaymentSessionResultRequest.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/request/purchase/PaymentSessionResultRequest.java
@@ -1,0 +1,18 @@
+package com.lumen.awsspringbootservice.dto.request.purchase;
+
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PaymentSessionResultRequest {
+    private String userId;
+    private String purchaseId;
+    private PurchaseStatus status;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/response/ExceptionMessageResponse.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/response/ExceptionMessageResponse.java
@@ -1,0 +1,14 @@
+package com.lumen.awsspringbootservice.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExceptionMessageResponse {
+    private String message;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/response/StandardMessageResponse.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/response/StandardMessageResponse.java
@@ -1,0 +1,16 @@
+package com.lumen.awsspringbootservice.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StandardMessageResponse {
+
+    private String message;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/dto/response/purchase/CreatePaymentSessionResponse.java
+++ b/src/main/java/com/lumen/awsspringbootservice/dto/response/purchase/CreatePaymentSessionResponse.java
@@ -1,0 +1,15 @@
+package com.lumen.awsspringbootservice.dto.response.purchase;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreatePaymentSessionResponse {
+    private String paymentUrl;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/entity/PaymentSession.java
+++ b/src/main/java/com/lumen/awsspringbootservice/entity/PaymentSession.java
@@ -1,0 +1,28 @@
+package com.lumen.awsspringbootservice.entity;
+
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class PaymentSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    private PurchaseStatus status;
+    private String webhookUrl;
+    private String userId;
+    private String purchaseId;
+}

--- a/src/main/java/com/lumen/awsspringbootservice/entity/Purchase.java
+++ b/src/main/java/com/lumen/awsspringbootservice/entity/Purchase.java
@@ -1,6 +1,6 @@
 package com.lumen.awsspringbootservice.entity;
 
-import com.lumen.awsspringbootservice.enums.PlanType;
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,10 +31,13 @@ public class Purchase {
     @JoinColumn(name = "movie_id")
     private Movie movie;
 
-    @Enumerated(EnumType.STRING)
-    private PlanType selectedPlanType;
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    private MoviePlan selectedMoviePlan;
 
     private LocalDateTime purchasedAt;
     private LocalDateTime expiresAt;
+
+    @Enumerated(EnumType.STRING)
+    private PurchaseStatus purchaseStatus;
 }
 

--- a/src/main/java/com/lumen/awsspringbootservice/enums/PurchaseStatus.java
+++ b/src/main/java/com/lumen/awsspringbootservice/enums/PurchaseStatus.java
@@ -1,0 +1,7 @@
+package com.lumen.awsspringbootservice.enums;
+
+public enum PurchaseStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/com/lumen/awsspringbootservice/exception/PaymentException.java
+++ b/src/main/java/com/lumen/awsspringbootservice/exception/PaymentException.java
@@ -1,0 +1,11 @@
+package com.lumen.awsspringbootservice.exception;
+
+public class PaymentException extends RuntimeException {
+    public PaymentException(String message) {
+        super(message);
+    }
+
+    public PaymentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/lumen/awsspringbootservice/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.lumen.awsspringbootservice.exception.handler;
+
+import com.lumen.awsspringbootservice.dto.response.ExceptionMessageResponse;
+import com.lumen.awsspringbootservice.exception.NotFoundException;
+import com.lumen.awsspringbootservice.exception.PaymentException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionMessageResponse> handleNotFoundException(NotFoundException ex) {
+        return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(PaymentException.class)
+    public ResponseEntity<ExceptionMessageResponse> handlePaymentException(PaymentException ex) {
+        return buildResponse(HttpStatus.PAYMENT_REQUIRED, ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionMessageResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("Validation error");
+        return buildResponse(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ExceptionMessageResponse> handleIllegalStateException(IllegalStateException ex) {
+        return buildResponse(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ExceptionMessageResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionMessageResponse> handleGenericException(Exception ex) {
+        log.error("Unexpected error: ", ex);
+        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error");
+    }
+
+    private ResponseEntity<ExceptionMessageResponse> buildResponse(HttpStatus status, String message) {
+        return ResponseEntity.status(status).body(ExceptionMessageResponse.builder().message(message).build());
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/repository/PaymentSessionRepository.java
+++ b/src/main/java/com/lumen/awsspringbootservice/repository/PaymentSessionRepository.java
@@ -1,0 +1,9 @@
+package com.lumen.awsspringbootservice.repository;
+
+import com.lumen.awsspringbootservice.entity.PaymentSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PaymentSessionRepository extends JpaRepository<PaymentSession, UUID> {
+}

--- a/src/main/java/com/lumen/awsspringbootservice/repository/PurchaseRepository.java
+++ b/src/main/java/com/lumen/awsspringbootservice/repository/PurchaseRepository.java
@@ -1,0 +1,12 @@
+package com.lumen.awsspringbootservice.repository;
+
+import com.lumen.awsspringbootservice.entity.Purchase;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PurchaseRepository extends JpaRepository<Purchase, UUID> {
+
+    Optional<Purchase> findByUserIdAndSelectedMoviePlanId(UUID userId, UUID selectedMoviePlanId);
+}

--- a/src/main/java/com/lumen/awsspringbootservice/repository/RecordRepository.java
+++ b/src/main/java/com/lumen/awsspringbootservice/repository/RecordRepository.java
@@ -1,0 +1,10 @@
+package com.lumen.awsspringbootservice.repository;
+
+import com.lumen.awsspringbootservice.entity.Record;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.UUID;
+
+public interface RecordRepository extends JpaRepository<Record, UUID>, JpaSpecificationExecutor<Record> {
+}

--- a/src/main/java/com/lumen/awsspringbootservice/repository/UserRepository.java
+++ b/src/main/java/com/lumen/awsspringbootservice/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.lumen.awsspringbootservice.repository;
+
+import com.lumen.awsspringbootservice.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID>, JpaSpecificationExecutor<User> {
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/AuthService.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/AuthService.java
@@ -1,0 +1,6 @@
+package com.lumen.awsspringbootservice.service;
+
+public interface AuthService {
+
+    String getUserId(String token);
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/MockPaymentService.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/MockPaymentService.java
@@ -1,0 +1,16 @@
+package com.lumen.awsspringbootservice.service;
+
+import com.lumen.awsspringbootservice.dto.request.purchase.CreatePaymentSessionRequest;
+import com.lumen.awsspringbootservice.entity.PaymentSession;
+
+public interface MockPaymentService {
+
+    String createPaymentSession(CreatePaymentSessionRequest request);
+
+    void approvePaymentSession(String id);
+
+    void cancelPaymentSession(String id);
+
+    PaymentSession getPaymentSessionById(String id);
+
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/PurchaseService.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/PurchaseService.java
@@ -1,0 +1,10 @@
+package com.lumen.awsspringbootservice.service;
+
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+
+public interface PurchaseService {
+
+    String createPurchaseSession(String movieId, String moviePlanId, String userId);
+
+    void setPurchaseSessionResult(String purchaseId, PurchaseStatus purchaseStatus);
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/impl/MockPaymentServiceImpl.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/impl/MockPaymentServiceImpl.java
@@ -1,0 +1,117 @@
+package com.lumen.awsspringbootservice.service.impl;
+
+import com.lumen.awsspringbootservice.dto.request.purchase.CreatePaymentSessionRequest;
+import com.lumen.awsspringbootservice.dto.request.purchase.PaymentSessionResultRequest;
+import com.lumen.awsspringbootservice.entity.PaymentSession;
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+import com.lumen.awsspringbootservice.exception.NotFoundException;
+import com.lumen.awsspringbootservice.exception.PaymentException;
+import com.lumen.awsspringbootservice.repository.PaymentSessionRepository;
+import com.lumen.awsspringbootservice.service.MockPaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MockPaymentServiceImpl implements MockPaymentService {
+
+    private final PaymentSessionRepository paymentSessionRepository;
+    private final WebClient webClient = WebClient.create();
+
+    @Override
+    public String createPaymentSession(CreatePaymentSessionRequest request) {
+
+        PaymentSession session = paymentSessionRepository.save(PaymentSession.builder()
+                .status(PurchaseStatus.PENDING)
+                .userId(request.getUserId())
+                .purchaseId(request.getPurchaseId())
+                .webhookUrl(request.getWebhookUrl()).build());
+
+        return session.getId().toString();
+    }
+
+    @Override
+    public PaymentSession getPaymentSessionById(String id) {
+        PaymentSession session = paymentSessionRepository.findById(UUID.fromString(id)).orElseThrow(() -> new NotFoundException("PaymentSession with id " + id + " not found"));
+        if (session.getStatus().equals(PurchaseStatus.PENDING)) {
+            return session;
+        }
+        throw new NotFoundException("Pending PaymentSession with id " + id + " not found");
+    }
+
+
+    @Override
+    @Transactional
+    public void approvePaymentSession(String id) {
+        PaymentSession session = paymentSessionRepository.findById(UUID.fromString(id)).orElseThrow(() -> new NotFoundException("PaymentSession with id " + id + " not found"));
+        if (session.getStatus().equals(PurchaseStatus.PENDING)) {
+            session.setStatus(PurchaseStatus.SUCCESS);
+            paymentSessionRepository.save(session);
+
+            PaymentSessionResultRequest approvePaymentSessionRequest = PaymentSessionResultRequest.builder()
+                    .userId(session.getUserId())
+                    .purchaseId(session.getPurchaseId())
+                    .status(PurchaseStatus.SUCCESS)
+                    .build();
+
+            webClient.post()
+                    .uri(session.getWebhookUrl())
+                    .bodyValue(approvePaymentSessionRequest)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            response -> {
+                                log.error("Webhook callback failed for session {}", id);
+                                throw new PaymentException("PaymentSession with id " + id + " webhook callback failed");
+                            }
+                    )
+                    .toBodilessEntity()
+                    .doOnSuccess(r -> log.info("Webhook callback success for session {}", id))
+                    .block();
+
+
+        } else {
+            throw new IllegalStateException("Session not found or already processed: " + id);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void cancelPaymentSession(String id) {
+        PaymentSession session = paymentSessionRepository.findById(UUID.fromString(id)).orElseThrow(() -> new NotFoundException("PaymentSession with id " + id + " not found"));
+        if (session.getStatus().equals(PurchaseStatus.PENDING)) {
+            session.setStatus(PurchaseStatus.FAILED);
+            paymentSessionRepository.save(session);
+
+            PaymentSessionResultRequest approvePaymentSessionRequest = PaymentSessionResultRequest.builder()
+                    .userId(session.getUserId())
+                    .purchaseId(session.getPurchaseId())
+                    .status(PurchaseStatus.FAILED)
+                    .build();
+
+            webClient.post()
+                    .uri(session.getWebhookUrl())
+                    .bodyValue(approvePaymentSessionRequest)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            response -> {
+                                log.error("Webhook callback failed for session {}", id);
+                                throw new PaymentException("PaymentSession with id " + id + " webhook callback failed");
+                            }
+                    )
+                    .toBodilessEntity()
+                    .doOnSuccess(r -> log.info("Webhook callback success for session {}", id))
+                    .block();
+
+        }
+        throw new NotFoundException("Pending PaymentSession with id " + id + " not found");
+
+    }
+}

--- a/src/main/java/com/lumen/awsspringbootservice/service/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/lumen/awsspringbootservice/service/impl/PurchaseServiceImpl.java
@@ -1,0 +1,104 @@
+package com.lumen.awsspringbootservice.service.impl;
+
+import com.lumen.awsspringbootservice.dto.request.purchase.CreatePaymentSessionRequest;
+import com.lumen.awsspringbootservice.dto.response.purchase.CreatePaymentSessionResponse;
+import com.lumen.awsspringbootservice.entity.Purchase;
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+import com.lumen.awsspringbootservice.exception.NotFoundException;
+import com.lumen.awsspringbootservice.exception.PaymentException;
+import com.lumen.awsspringbootservice.repository.MoviePlanRepository;
+import com.lumen.awsspringbootservice.repository.MovieRepository;
+import com.lumen.awsspringbootservice.repository.PurchaseRepository;
+import com.lumen.awsspringbootservice.repository.UserRepository;
+import com.lumen.awsspringbootservice.service.PurchaseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class PurchaseServiceImpl implements PurchaseService {
+
+    private final PurchaseRepository purchaseRepository;
+    private final MovieRepository movieRepository;
+    private final UserRepository userRepository;
+    private final MoviePlanRepository moviePlanRepository;
+
+
+    @Value("${app.payment.provider.url}")
+    private String paymentUrl;
+
+    @Value("${app.purchase.webhook.endpoint}")
+    private String webhookEndpoint;
+
+    @Value("${server.address:localhost}")
+    private String serverAddress;
+
+    @Value("${server.port:8080}")
+    private int serverPort;
+
+    private final WebClient webClient = WebClient.create();
+
+    @Transactional
+    public String createPurchaseSession(String movieId, String moviePlanId, String userId) {
+        if (purchaseRepository.findByUserIdAndSelectedMoviePlanId(UUID.fromString(userId), UUID.fromString(moviePlanId)).isPresent()) {
+            log.error("Purchase is already in process");
+            throw new IllegalStateException("Purchase is already in process");
+        }
+
+        Purchase purchase = Purchase.builder()
+                .user(userRepository
+                        .findById(UUID.fromString(userId))
+                        .orElseThrow(() -> new NotFoundException("User with id " + userId + " not found")))
+                .movie(movieRepository
+                        .findById(UUID.fromString(movieId))
+                        .orElseThrow(() -> new NotFoundException("Movie with id " + movieId + " not found")))
+                .selectedMoviePlan(moviePlanRepository.findById(UUID.fromString(moviePlanId))
+                        .orElseThrow(() -> new NotFoundException("MoviePlan with id " + moviePlanId + " not found")))
+                .purchaseStatus(PurchaseStatus.PENDING)
+                .build();
+
+        purchase = purchaseRepository.save(purchase);
+
+
+        CreatePaymentSessionRequest paymentSessionRequest = CreatePaymentSessionRequest.builder()
+                .purchaseId(purchase.getId().toString())
+                .userId(userId)
+                .webhookUrl(String.format(
+                        "http://%s:%d/%s",
+                        serverAddress, serverPort, webhookEndpoint
+                ))
+                .build();
+
+        CreatePaymentSessionResponse response = webClient.post()
+                .uri(paymentUrl)
+                .bodyValue(paymentSessionRequest)
+                .retrieve()
+                .bodyToMono(CreatePaymentSessionResponse.class)
+                .block();
+
+        if (response == null) {
+            log.error("Create payment session failed");
+            throw new PaymentException("Create payment session failed");
+        }
+
+        return response.getPaymentUrl();
+    }
+
+    public void setPurchaseSessionResult(String purchaseId, PurchaseStatus purchaseStatus) {
+        Purchase purchase = purchaseRepository.findById(UUID.fromString(purchaseId)).orElseThrow(() -> new NotFoundException("Purchase with id " + purchaseId + " not found"));
+
+        purchase.setPurchaseStatus(purchaseStatus);
+        if (purchaseStatus == PurchaseStatus.SUCCESS) {
+            purchase.setPurchasedAt(LocalDateTime.now());
+        }
+        purchaseRepository.save(purchase);
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -14,3 +14,5 @@ aws.s3.movie.video.folder.name=${AWS_S3_MOVIE_VIDEO_FOLDER_NAME}
 aws.credentials.access.key=${AWS_CREDENTIALS_ACCESS_KEY}
 aws.credentials.secret.key=${AWS_CREDENTIALS_SECRET_KEY}
 aws.s3.endpoint=${AWS_S3_ENDPOINT}
+app.payment.provider.url=http://localhost:8080/api/v1/mock/payments/create-session
+app.purchase.webhook.endpoint=/api/v1/lumen/purchases/callback

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -12,3 +12,5 @@ aws.s3.movie.poster.bucket.name=test-movie-posters
 aws.s3.movie.poster.folder.name=posters
 aws.s3.movie.video.bucket.name=test-movie-videos
 aws.s3.movie.video.folder.name=videos
+app.payment.provider.url=http://localhost:8080/api/v1/mock/payments
+app.purchase.webhook.endpoint=/api/v1/lumen/purchases/callback

--- a/src/test/java/com/lumen/awsspringbootservice/controller/MovieControllerImplTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/controller/MovieControllerImplTest.java
@@ -15,6 +15,7 @@ import com.lumen.awsspringbootservice.enums.Genre;
 import com.lumen.awsspringbootservice.enums.PlanType;
 import com.lumen.awsspringbootservice.mapper.MovieMapper;
 import com.lumen.awsspringbootservice.service.MovieService;
+import com.lumen.awsspringbootservice.service.PurchaseService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -50,6 +51,9 @@ class MovieControllerImplTest {
 
     @MockitoBean
     private MovieMapper movieMapper;
+
+    @MockitoBean
+    private PurchaseService purchaseService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -165,4 +169,29 @@ class MovieControllerImplTest {
 
         Mockito.verify(movieService).getMovieVideoUrl(movieId);
     }
+
+    @Test
+    @DisplayName("POST /movies/{id}/{moviePlanId}/purchase should return 201 with payment URL")
+    void shouldReturnCreatedPaymentSession_whenPurchaseMovie() throws Exception {
+        // given
+        String movieId = "movie-123";
+        String moviePlanId = "plan-456";
+        String userId = "user-789";
+        String expectedUrl = "https://mock.payment/session123";
+
+        Mockito.when(purchaseService.createPurchaseSession(movieId, moviePlanId, userId))
+                .thenReturn(expectedUrl);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/lumen/movies/{id}/{moviePlanId}/purchase", movieId, moviePlanId)
+                        .param("userId", userId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.paymentUrl").value(expectedUrl));
+
+        // verify
+        Mockito.verify(purchaseService).createPurchaseSession(movieId, moviePlanId, userId);
+    }
+
 }

--- a/src/test/java/com/lumen/awsspringbootservice/repository/BaseRepositoryTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/repository/BaseRepositoryTest.java
@@ -42,11 +42,11 @@ public abstract class BaseRepositoryTest {
                 .build();
     }
 
-    protected Purchase buildPurchase(User user, Movie movie, PlanType planType) {
+    protected Purchase buildPurchase(User user, Movie movie, MoviePlan moviePlan) {
         return Purchase.builder()
                 .user(user)
                 .movie(movie)
-                .selectedPlanType(planType)
+                .selectedMoviePlan(moviePlan)
                 .purchasedAt(LocalDateTime.now())
                 .expiresAt(LocalDateTime.now().plusDays(30))
                 .build();

--- a/src/test/java/com/lumen/awsspringbootservice/service/PurchaseServiceImplTest.java
+++ b/src/test/java/com/lumen/awsspringbootservice/service/PurchaseServiceImplTest.java
@@ -1,0 +1,228 @@
+package com.lumen.awsspringbootservice.service;
+
+import com.lumen.awsspringbootservice.dto.response.purchase.CreatePaymentSessionResponse;
+import com.lumen.awsspringbootservice.entity.Movie;
+import com.lumen.awsspringbootservice.entity.MoviePlan;
+import com.lumen.awsspringbootservice.entity.Purchase;
+import com.lumen.awsspringbootservice.entity.User;
+import com.lumen.awsspringbootservice.enums.PurchaseStatus;
+import com.lumen.awsspringbootservice.exception.NotFoundException;
+import com.lumen.awsspringbootservice.exception.PaymentException;
+import com.lumen.awsspringbootservice.repository.MoviePlanRepository;
+import com.lumen.awsspringbootservice.repository.MovieRepository;
+import com.lumen.awsspringbootservice.repository.PurchaseRepository;
+import com.lumen.awsspringbootservice.repository.UserRepository;
+import com.lumen.awsspringbootservice.service.impl.PurchaseServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PurchaseServiceImpl Simplified Unit Tests")
+class PurchaseServiceImplTest {
+
+    @Mock
+    private PurchaseRepository purchaseRepository;
+    @Mock
+    private MovieRepository movieRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MoviePlanRepository moviePlanRepository;
+    @InjectMocks
+    private PurchaseServiceImpl purchaseService;
+
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(purchaseService, "paymentUrl",
+                "http://mock-payment-service:8082/api/v1/payments/create-session");
+
+        ReflectionTestUtils.setField(purchaseService, "webhookEndpoint",
+                "api/v1/lumen/purchases/callback");
+
+        ReflectionTestUtils.setField(purchaseService, "serverAddress", "localhost");
+        ReflectionTestUtils.setField(purchaseService, "serverPort", 8080);
+    }
+
+    @Nested
+    @DisplayName("createPurchaseSession Tests")
+    class CreatePurchaseSessionTests {
+
+        @Test
+        @DisplayName("Should create purchase and return payment URL successfully")
+        void shouldReturnPaymentUrlWhenSuccess() {
+            UUID userId = UUID.randomUUID();
+            UUID movieId = UUID.randomUUID();
+            UUID moviePlanId = UUID.randomUUID();
+
+            User user = new User();
+            Movie movie = new Movie();
+            MoviePlan plan = new MoviePlan();
+            Purchase purchase = Purchase.builder().id(UUID.randomUUID()).build();
+
+            when(purchaseRepository.findByUserIdAndSelectedMoviePlanId(userId, moviePlanId))
+                    .thenReturn(Optional.empty());
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(movieRepository.findById(movieId)).thenReturn(Optional.of(movie));
+            when(moviePlanRepository.findById(moviePlanId)).thenReturn(Optional.of(plan));
+            when(purchaseRepository.save(any())).thenReturn(purchase);
+
+            WebClient mockWebClient = mock(WebClient.class, RETURNS_DEEP_STUBS);
+            CreatePaymentSessionResponse mockResponse = new CreatePaymentSessionResponse();
+            mockResponse.setPaymentUrl("https://mock.payment/session123");
+
+            when(mockWebClient.post()
+                    .uri(anyString())
+                    .bodyValue(any())
+                    .retrieve()
+                    .bodyToMono(CreatePaymentSessionResponse.class)
+                    .block())
+                    .thenReturn(mockResponse);
+
+            // підміняємо приватне поле webClient у сервісі
+            ReflectionTestUtils.setField(purchaseService, "webClient", mockWebClient);
+
+            // when
+            String result = purchaseService.createPurchaseSession(
+                    movieId.toString(),
+                    moviePlanId.toString(),
+                    userId.toString());
+
+            // then
+            assertEquals("https://mock.payment/session123", result);
+            verify(purchaseRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalStateException if purchase already exists")
+        void shouldThrowWhenPurchaseAlreadyExists() {
+            UUID userId = UUID.randomUUID();
+            UUID moviePlanId = UUID.randomUUID();
+
+            when(purchaseRepository.findByUserIdAndSelectedMoviePlanId(userId, moviePlanId))
+                    .thenReturn(Optional.of(new Purchase()));
+
+            assertThrows(IllegalStateException.class, () ->
+                    purchaseService.createPurchaseSession(
+                            UUID.randomUUID().toString(),
+                            moviePlanId.toString(),
+                            userId.toString()));
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when user not found")
+        void shouldThrowWhenUserNotFound() {
+            UUID userId = UUID.randomUUID();
+            UUID movieId = UUID.randomUUID();
+            UUID moviePlanId = UUID.randomUUID();
+
+            when(purchaseRepository.findByUserIdAndSelectedMoviePlanId(userId, moviePlanId))
+                    .thenReturn(Optional.empty());
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () ->
+                    purchaseService.createPurchaseSession(
+                            movieId.toString(),
+                            moviePlanId.toString(),
+                            userId.toString()));
+        }
+
+        @Test
+        @DisplayName("Should throw PaymentException if response is null")
+        void shouldThrowPaymentExceptionWhenResponseNull() {
+            UUID userId = UUID.randomUUID();
+            UUID movieId = UUID.randomUUID();
+            UUID moviePlanId = UUID.randomUUID();
+
+            User user = new User();
+            Movie movie = new Movie();
+            MoviePlan plan = new MoviePlan();
+            Purchase purchase = Purchase.builder().id(UUID.randomUUID()).build();
+
+            when(purchaseRepository.findByUserIdAndSelectedMoviePlanId(userId, moviePlanId))
+                    .thenReturn(Optional.empty());
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(movieRepository.findById(movieId)).thenReturn(Optional.of(movie));
+            when(moviePlanRepository.findById(moviePlanId)).thenReturn(Optional.of(plan));
+            when(purchaseRepository.save(any())).thenReturn(purchase);
+
+            WebClient mockWebClient = mock(WebClient.class, RETURNS_DEEP_STUBS);
+            when(mockWebClient.post()
+                    .uri(anyString())
+                    .bodyValue(any())
+                    .retrieve()
+                    .bodyToMono(CreatePaymentSessionResponse.class)
+                    .block())
+                    .thenReturn(null);
+
+            ReflectionTestUtils.setField(purchaseService, "webClient", mockWebClient);
+
+            assertThrows(PaymentException.class, () ->
+                    purchaseService.createPurchaseSession(
+                            movieId.toString(),
+                            moviePlanId.toString(),
+                            userId.toString()));
+        }
+    }
+
+    @Nested
+    @DisplayName("setPurchaseSessionResult Tests")
+    class SetPurchaseSessionResultTests {
+
+        @Test
+        @DisplayName("Should update status and set purchasedAt when SUCCESS")
+        void shouldSetPurchasedAtWhenSuccess() {
+            UUID purchaseId = UUID.randomUUID();
+            Purchase purchase = new Purchase();
+
+            when(purchaseRepository.findById(purchaseId)).thenReturn(Optional.of(purchase));
+
+            purchaseService.setPurchaseSessionResult(purchaseId.toString(), PurchaseStatus.SUCCESS);
+
+            assertEquals(PurchaseStatus.SUCCESS, purchase.getPurchaseStatus());
+            assertNotNull(purchase.getPurchasedAt());
+            verify(purchaseRepository).save(purchase);
+        }
+
+        @Test
+        @DisplayName("Should update status without purchasedAt when FAILED")
+        void shouldSetStatusWithoutPurchasedAtWhenFailed() {
+            UUID purchaseId = UUID.randomUUID();
+            Purchase purchase = new Purchase();
+
+            when(purchaseRepository.findById(purchaseId)).thenReturn(Optional.of(purchase));
+
+            purchaseService.setPurchaseSessionResult(purchaseId.toString(), PurchaseStatus.FAILED);
+
+            assertEquals(PurchaseStatus.FAILED, purchase.getPurchaseStatus());
+            assertNull(purchase.getPurchasedAt());
+            verify(purchaseRepository).save(purchase);
+        }
+
+        @Test
+        @DisplayName("Should throw NotFoundException when purchase not found")
+        void shouldThrowWhenPurchaseNotFound() {
+            UUID purchaseId = UUID.randomUUID();
+            when(purchaseRepository.findById(purchaseId)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundException.class, () ->
+                    purchaseService.setPurchaseSessionResult(purchaseId.toString(), PurchaseStatus.SUCCESS));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implemented the complete movie purchase flow with mock payment integration.

---

## Details

### Added new logic in `PurchaseServiceImpl` to handle movie purchase sessions:
- Verifies existing purchases to prevent duplicates.  
- Creates new purchase records with `PENDING` status.  
- Dynamically builds webhook URL based on current host and port.  
- Sends `CreatePaymentSessionRequest` to mock payment provider via `WebClient`.  
- Handles `PaymentException` and `NotFoundException` gracefully.  

## Build:
<img width="790" height="159" alt="image" src="https://github.com/user-attachments/assets/101cef33-05d4-4d47-9478-f0d9d25946e9" />
